### PR TITLE
Add sqlalchemy indexes to vacancy table

### DIFF
--- a/services/vacancy-processor/src/database/models/tables.py
+++ b/services/vacancy-processor/src/database/models/tables.py
@@ -1,5 +1,5 @@
 from database.models import Base
-from sqlalchemy import Column, ForeignKey, Table
+from sqlalchemy import Column, ForeignKey, Table, Index
 
 
 __all__ = [
@@ -16,11 +16,25 @@ vacancy_grades_table: Table = Table(
     Column("grade_id", ForeignKey("grades.id", ondelete="RESTRICT"), primary_key=True),
 )
 
+# Reverse index to speed up lookups by grade -> vacancies
+Index(
+    "idx_vacancy_grades_grade_id_vacancy_id",
+    vacancy_grades_table.c.grade_id,
+    vacancy_grades_table.c.vacancy_id,
+)
+
 vacancy_skills_table: Table = Table(
     "vacancy_skills",
     Base.metadata,
     Column("vacancy_id", ForeignKey("vacancies.id", ondelete="CASCADE"), primary_key=True),
     Column("skill_id", ForeignKey("skills.id", ondelete="RESTRICT"), primary_key=True),
+)
+
+# Reverse index to speed up lookups by skill -> vacancies (used in relevance calc)
+Index(
+    "idx_vacancy_skills_skill_id_vacancy_id",
+    vacancy_skills_table.c.skill_id,
+    vacancy_skills_table.c.vacancy_id,
 )
 
 
@@ -29,4 +43,11 @@ vacancy_work_formats_table: Table = Table(
     Base.metadata,
     Column("vacancy_id", ForeignKey("vacancies.id", ondelete="CASCADE"), primary_key=True),
     Column("work_format_id", ForeignKey("work_formats.id", ondelete="RESTRICT"), primary_key=True),
+)
+
+# Reverse index to speed up lookups by work_format -> vacancies
+Index(
+    "idx_vacancy_work_formats_work_format_id_vacancy_id",
+    vacancy_work_formats_table.c.work_format_id,
+    vacancy_work_formats_table.c.vacancy_id,
 )

--- a/services/vacancy-processor/src/database/models/vacancy.py
+++ b/services/vacancy-processor/src/database/models/vacancy.py
@@ -43,4 +43,8 @@ class Vacancy(Base):
     __table_args__ = (
         Index("idx_vacancy_published_at_id", "published_at", "id"),
         Index("idx_vacancy_source_link", "source", "link", unique=True),
+        # Filter by profession via FK
+        Index("idx_vacancy_profession_id", "profession_id"),
+        # Common filter and sort pattern: source + published_at
+        Index("idx_vacancy_source_published_at", "source", "published_at"),
     )


### PR DESCRIPTION
Add database indexes to improve performance of complex vacancy search queries.

The indexes target `EXISTS` filters on association tables for grades, skills, and work formats, lookups by `profession_id`, and common filtering/sorting by `source` and `published_at`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6dd0124-2b38-4808-92be-d9cd3faaa9b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6dd0124-2b38-4808-92be-d9cd3faaa9b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

