### PR TITLE
Clean up duplicate vacancies daily

### DIFF
--- a/services/vacancy-parser/src/celery_app/beat.py
+++ b/services/vacancy-parser/src/celery_app/beat.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from celery.schedules import schedule
+from celery.schedules import crontab, schedule
 
 
 __all__ = ["beat_schedule"]
@@ -9,5 +9,9 @@ beat_schedule = {
     "parse-vacancies-every-10-minutes": {
         "task": "parse_vacancies",
         "schedule": schedule(run_every=timedelta(minutes=10)),
-    }
+    },
+    "cleanup-duplicate-vacancies-daily-03-00": {
+        "task": "cleanup_duplicate_vacancies",
+        "schedule": crontab(hour=3, minute=0),
+    },
 }

--- a/services/vacancy-parser/src/repositories/vacancy.py
+++ b/services/vacancy-parser/src/repositories/vacancy.py
@@ -1,5 +1,8 @@
-from database.models import Vacancy
+from collections.abc import Sequence
+
+from database.models import HabrVacancy, HeadHunterVacancy, TelegramVacancy, Vacancy
 from repositories import BaseVacancyRepository
+from sqlalchemy import delete, func, select
 
 
 __all__ = ["VacancyRepository"]
@@ -9,3 +12,46 @@ class VacancyRepository(BaseVacancyRepository[Vacancy]):
     """Репозиторий для работы с моделями вакансий."""
 
     model = Vacancy
+
+    async def _get_duplicate_ids_by_fingerprint(self, limit: int | None = None) -> list[int]:
+        """Возвращает ID вакансий-дублей по точному совпадению fingerprint.
+
+        В каждой группе по одному fingerprint сохраняется запись с максимальным
+        published_at (при равенстве — с максимальным id), остальные считаются дублями.
+        """
+        row_number = func.row_number().over(
+            partition_by=self.model.fingerprint,
+            order_by=(self.model.published_at.desc(), self.model.id.desc()),
+        ).label("rn")
+
+        subq = select(self.model.id, row_number).subquery()
+
+        stmt = select(subq.c.id).where(subq.c.rn > 1)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def _delete_by_ids(self, ids: Sequence[int]) -> int:
+        """Удаляет вакансии и соответствующие записи из дочерних таблиц."""
+        if not ids:
+            return 0
+
+        await self._session.execute(delete(HabrVacancy).where(HabrVacancy.id.in_(ids)))
+        await self._session.execute(delete(HeadHunterVacancy).where(HeadHunterVacancy.id.in_(ids)))
+        await self._session.execute(delete(TelegramVacancy).where(TelegramVacancy.id.in_(ids)))
+
+        result = await self._session.execute(
+            delete(Vacancy).where(Vacancy.id.in_(ids)).returning(Vacancy.id)
+        )
+        deleted_ids = result.scalars().all()
+        return len(deleted_ids)
+
+    async def cleanup_duplicates_by_fingerprint(self, limit: int | None = None) -> int:
+        """Удаляет дубли вакансий по fingerprint, оставляя самую актуальную.
+
+        Возвращает количество удалённых записей.
+        """
+        duplicate_ids = await self._get_duplicate_ids_by_fingerprint(limit=limit)
+        return await self._delete_by_ids(duplicate_ids)

--- a/services/vacancy-parser/src/services/vacancy.py
+++ b/services/vacancy-parser/src/services/vacancy.py
@@ -15,3 +15,9 @@ class VacancyService(BaseVacancyService[VacancyRead, VacancyCreate, VacancyRepos
 
     def _get_repo(self) -> "VacancyRepository":
         return self._uow.vacancies
+
+    async def cleanup_duplicates_by_fingerprint(self, limit: int | None = None) -> int:
+        """Удаляет дубли вакансий по fingerprint и фиксирует транзакцию."""
+        deleted = await self.repo.cleanup_duplicates_by_fingerprint(limit=limit)
+        await self.commit()
+        return deleted


### PR DESCRIPTION
Add a daily Celery task to remove duplicate vacancies by fingerprint, retaining the most recently published one.

Parallel parsers can sometimes add identical vacancies (e.g., from different cities) to the database simultaneously. This task ensures that only the most relevant version of a vacancy is kept, based on its publication date and unique fingerprint.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3fbfe56-4322-45e7-90d1-bf11e7d83ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3fbfe56-4322-45e7-90d1-bf11e7d83ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

