### PR TITLE
Handle duplicate head hunter vacancies

### DIFF
--- a/services/vacancy-parser/src/parsers/base.py
+++ b/services/vacancy-parser/src/parsers/base.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
+from typing import List
 
 from common.logger import get_logger
 from unitofwork import UnitOfWork
+from constants.fingerprint import FINGERPRINT_SIMILARITY_THRESHOLD
 
 
 __all__ = ["BaseParser"]
@@ -34,6 +36,69 @@ class BaseParser[VacancyServiceType, VacancyCreateType](ABC):
         if not self._vacancies_batch:
             return
 
-        await self.service.add_vacancies_bulk(self._vacancies_batch)  # type: ignore[attr-defined]
-        logger.info("Commited batch of %d vacancies for parser %s", len(self._vacancies_batch), self.__class__.__name__)
+        # Убираем дубликаты внутри текущего батча по схожести fingerprint.
+        deduped_batch: List[VacancyCreateType] = self._deduplicate_batch(self._vacancies_batch)
+
+        await self.service.add_vacancies_bulk(deduped_batch)  # type: ignore[attr-defined]
+        logger.info(
+            "Committed %d (from %d) vacancies for parser %s",
+            len(deduped_batch),
+            len(self._vacancies_batch),
+            self.__class__.__name__,
+        )
         self._vacancies_batch = []
+
+    def _deduplicate_batch(self, vacancies: list[VacancyCreateType]) -> list[VacancyCreateType]:
+        """Удаляет дубликаты внутри одного батча по схожести fingerprint.
+
+        Если найдены несколько очень похожих вакансий, оставляет первую и
+        обновляет у неё поле published_at на максимальное из объединяемых.
+        """
+        if len(vacancies) <= 1:
+            return vacancies
+
+        def trigrams(s: str) -> set[str]:
+            if len(s) < 3:
+                return {s} if s else set()
+            return {s[i : i + 3] for i in range(len(s) - 2)}
+
+        def trigram_similarity(a: str, b: str) -> float:
+            ta = trigrams(a)
+            tb = trigrams(b)
+            if not ta and not tb:
+                return 1.0
+            if not ta or not tb:
+                return 0.0
+            intersection = len(ta & tb)
+            # Dice coefficient — близко к pg_trgm similarity
+            return (2.0 * intersection) / (len(ta) + len(tb))
+
+        result: list[VacancyCreateType] = []
+
+        for candidate in vacancies:
+            is_duplicate = False
+            for kept in result:
+                similarity = trigram_similarity(
+                    str(getattr(candidate, "fingerprint")), str(getattr(kept, "fingerprint"))
+                )
+                if similarity > FINGERPRINT_SIMILARITY_THRESHOLD:
+                    # Считаем дубликатом: переносим максимальную дату публикации к сохранённому экземпляру
+                    cand_dt = getattr(candidate, "published_at")
+                    kept_dt = getattr(kept, "published_at")
+                    if cand_dt > kept_dt:
+                        setattr(kept, "published_at", cand_dt)
+                    is_duplicate = True
+                    break
+
+            if not is_duplicate:
+                result.append(candidate)
+
+        if len(result) != len(vacancies):
+            logger.debug(
+                "Deduplicated batch: %d -> %d items for parser %s",
+                len(vacancies),
+                len(result),
+                self.__class__.__name__,
+            )
+
+        return result


### PR DESCRIPTION
Add in-batch deduplication for vacancies based on fingerprint similarity to prevent duplicates from being saved when they arrive in the same parsing batch.

The existing duplicate check only works for vacancies already present in the database. If two very similar or identical vacancies are fetched within the same parsing run (i.e., in the same batch), both would be considered "new" and saved. This change introduces a pre-insertion deduplication step within the batch, merging similar entries and updating the `published_at` to the latest date.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e699898-7989-4298-9b98-35cd1a52d858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e699898-7989-4298-9b98-35cd1a52d858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

